### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/server/middleware/refererCheck.ts
+++ b/server/middleware/refererCheck.ts
@@ -1,4 +1,5 @@
 export default defineEventHandler((event) => {
+  const { URL } = globalThis;
   const referer = event.node.req.headers.referer;
   const url = getRequestURL(event);
   const allowedReferer =
@@ -8,7 +9,16 @@ export default defineEventHandler((event) => {
 
   const securePaths = ["/api/createServer", "/api/ai"];
   if (securePaths.includes(url.pathname)) {
-    if (!referer || !referer.startsWith(allowedReferer)) {
+    const allowedHosts = process.env.NODE_ENV === "development"
+      ? ["localhost:3000"]
+      : ["magicthrust.vercel.app"];
+    let refererHost;
+    try {
+      refererHost = new URL(referer).host;
+    } catch {
+      throw createError({ statusCode: 401, statusMessage: "Unauthorized" });
+    }
+    if (!referer || !allowedHosts.includes(refererHost)) {
       throw createError({ statusCode: 401, statusMessage: "Unauthorized" });
     }
   }


### PR DESCRIPTION
Potential fix for [https://github.com/floki1250/MagicThrust/security/code-scanning/1](https://github.com/floki1250/MagicThrust/security/code-scanning/1)

To fix the issue, the `referer` value should be parsed using a URL parsing library to extract its host component. The host should then be compared against a whitelist of allowed hosts to ensure that the `referer` is valid. This approach eliminates the risk of substring-based bypasses and ensures that only exact matches or valid subdomains are allowed.

**Steps to implement the fix:**
1. Parse the `referer` value using the `URL` constructor to extract its host.
2. Define a whitelist of allowed hosts (e.g., `localhost:3000` for development and `magicthrust.vercel.app` for production).
3. Check if the extracted host is included in the whitelist.
4. Throw an error if the `referer` is invalid.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
